### PR TITLE
Add debian testing instructions and simplify Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
-
 # This container will install SeroBA from master
 #
 FROM debian:testing
 
 # Install the dependancies
-RUN  apt-get update -qq && apt-get install -y git bowtie2 cd-hit fastaq libc6 libfml0 libgcc1 libminimap0 libstdc++6 mummer python3 python3-setuptools python3-dev python3-pysam python3-pymummer     python3-dendropy gcc g++ zlib1g-dev
-RUN apt-get -y install wget make unzip python3-pip python-pip python3-tk build-essential libbz2-dev liblzma-dev libfreetype6 libfreetype6-dev libpng-dev libxft-dev
+RUN apt-get update -qq && apt-get install -y ariba python3-pip
+
 # Get the latest code from github and install
 RUN git clone https://github.com/sanger-pathogens/ariba.git && cd ariba && python3 setup.py install
-RUN git clone https://github.com/eppinglen/seroba
+RUN git clone https://github.com/sanger-pathogens/seroba
 RUN cd seroba  && ./install_dependencies.sh
-env PATH /seroba/build:$PATH
+ENV PATH /seroba/build:$PATH
 RUN export PATH
 RUN cd seroba && python3 setup.py install
 RUN cd seroba && seroba createDBs database/ 71

--- a/README.md
+++ b/README.md
@@ -70,26 +70,39 @@ possible so add new serotypes by adding the references sequence to the
 
 ## Installation
 
-### Debian Testing/Ubuntu 16.04 (Xenial)
+### Debian Testing
+
+Install the dependancies:
+```
+sudo apt-get update
+sudo apt-get install ariba python3-pip
+```
+
+Manually install [KMC version 3](https://github.com/refresh-bio/KMC/releases) (version 2 is the latest in Debian but is incompatible).
+Add the binaries to your PATH (e.g. in your bash profile).
+```
+mkdir kmc && cd kmc
+wget https://github.com/refresh-bio/KMC/releases/download/v3.0.0/KMC3.linux.tar.gz
+tar xvfz KMC3.linux.tar.gz
+export PATH=$PWD:$PATH
+```
+
+Finally install SeroBA:
+```
+pip3 install seroba
+```
+
+### Ubuntu 16.04 (Xenial)
 
 SeroBA has the following dependencies, which need to be installed:
   * Python3 version >= 3.3.2
   * KMC version >= 3.0
-  * KMC_tools version >= 3.0
   * MUMmer version >= 3.1
 
 Once the dependencies are installed, install SeroBA using pip:
-
-    pip3 install seroba
-
-If this dependencies are installed, you can download the latest release from this github repository,or clone the repository.
-Then run the tests:
-
-    python3 setup.py test
-
-If the tests all pass, install:
-
-    python3 setup.py install
+```
+pip3 install seroba
+```
 
 # Linux/OSX/Windows/Cloud
 ## Docker


### PR DESCRIPTION
Adds some more details for installing on a clean Debian testing system, and simplify the dockerfile, since ARIBA brings in most of the dependancies. Could @eppinglen check this. No need for a new version number.