### PR TITLE
let tempfile determine temp dir location

### DIFF
--- a/seroba/get_pneumocat_data.py
+++ b/seroba/get_pneumocat_data.py
@@ -98,7 +98,7 @@ class GetPneumocatData:
     def run(self):
         wd  = os.getcwd()
         os.makedirs(self.out_dir)
-        self.tmpdir = tempfile.mkdtemp(prefix ='pneumo.temp', dir=wd)
+        self.tmpdir = tempfile.mkdtemp(prefix ='pneumo.temp')
         os.chdir(self.tmpdir)
         self._get_pneumocat_db()
         self._pneumocat_db_2_tsv(self.serogroup_dir,self.out_file)

--- a/seroba/kmc.py
+++ b/seroba/kmc.py
@@ -10,9 +10,9 @@ def run_kmc(sequence_file,kmer_size,temp_dir,prefix):
     file_format = common.detect_sequence_format(sequence_file)
     kmer_count_files = os.path.join(temp_dir,prefix)
     if file_format == 'fa':
-        param = ' -ci1 -m1 -t1 -fm'
+        param = ' -ci1 -m2 -t1 -fm'
     elif file_format =='fq':
-        param = ' -ci4  -m1 -t1'
+        param = ' -ci4 -m2 -t1'
     print(param)
     command1=[ext_progs.exe('kmc') + ' -k'+kmer_size,param,sequence_file,kmer_count_files,temp_dir]
     print(' '.join(command1))

--- a/seroba/ref_db_creator.py
+++ b/seroba/ref_db_creator.py
@@ -42,7 +42,7 @@ class RefDbCreator:
 
             print("no such file")
 
-        self.temp_dir = tempfile.mkdtemp(prefix = 'temp_aribaX', dir=os.getcwd())
+        self.temp_dir = tempfile.mkdtemp(prefix = 'temp_aribaX')
         self.temp_fasta_ref = os.path.join(self.temp_dir,'temp_fasta_ref.fasta')
         self.temp_meta_ref = os.path.join(self.temp_dir,'temp_meta_ref.tsv')
         self.temp_fasta_genes = os.path.join(self.temp_dir,'temp_fasta_genes.fasta')
@@ -152,7 +152,7 @@ class RefDbCreator:
 
 
     def _create_complete_ariba_db(self,complete_cdhit_cluster):
-        temp_dir = tempfile.mkdtemp(prefix = 'temp_ariba', dir=os.getcwd())
+        temp_dir = tempfile.mkdtemp(prefix = 'temp_ariba')
         temp_dir = os.path.join(temp_dir,'ariba')
         command = ['ariba prepareref','-f',self.ref_fasta,'--all_coding no --max_noncoding_length 50000 --cdhit_clusters',complete_cdhit_cluster, temp_dir]
         os.system(' '.join(command))

--- a/seroba/serotyping.py
+++ b/seroba/serotyping.py
@@ -51,7 +51,7 @@ class Serotyping:
 
     def _run_kmc(self):
     #kmc on fw_read
-        temp_dir = tempfile.mkdtemp(prefix = 'temp.kmc', dir=os.getcwd())
+        temp_dir = tempfile.mkdtemp(prefix = 'temp.kmc')
         kmer_db_list = os.listdir(self.kmer_db)
         kmer_count = self.cov
         max_kmer_count = 0.0
@@ -255,7 +255,7 @@ class Serotyping:
         sub_dict = {'genes':[],'pseudo':[],'allele':[],'snps':[]}
         relevant_genetic_elements = dict.fromkeys(serotypes, sub_dict)
         allel_snp = serogroup_dict
-        tmpdir = tempfile.mkdtemp(prefix = 'temp.nucmer', dir=os.getcwd())
+        tmpdir = tempfile.mkdtemp(prefix = 'temp.nucmer')
         gene_ref = serogroup_fasta
         pymummer.nucmer.Runner(
             gene_ref,

--- a/seroba/tests/kmc_test.py
+++ b/seroba/tests/kmc_test.py
@@ -13,7 +13,7 @@ class TestKMC(unittest.TestCase):
         expected = os.path.join(data_dir,'expected_fa_database')
         sequence_file = os.path.join(data_dir,'test_build_kmc_database.fa')
         kmer_size = '51'
-        tmp_dir = tempfile.mkdtemp(prefix = 'temp.kmc', dir=os.getcwd())
+        tmp_dir = tempfile.mkdtemp(prefix = 'temp.kmc')
         got = kmc.run_kmc(sequence_file,kmer_size,tmp_dir,'count')
         trans_got = os.path.join(tmp_dir,'test_db')
         os.system(ext_progs.exe('kmc_tools')+' transform '+got+' histogram '+ trans_got)
@@ -24,7 +24,7 @@ class TestKMC(unittest.TestCase):
         expected = os.path.join(data_dir,'test_build_kmc_read_hist')
         sequence_file = os.path.join(data_dir,'test_build_kmc_read.fq.gz')
         kmer_size = '51'
-        tmp_dir = tempfile.mkdtemp(prefix = 'temp.kmc', dir=os.getcwd())
+        tmp_dir = tempfile.mkdtemp(prefix = 'temp.kmc')
         got = kmc.run_kmc(sequence_file,kmer_size,tmp_dir,'count')
         trans_got = os.path.join(tmp_dir,'test_db')
         os.system(ext_progs.exe('kmc_tools')+' transform '+got+' histogram '+ trans_got)

--- a/seroba/tests/ref_db_creator_test.py
+++ b/seroba/tests/ref_db_creator_test.py
@@ -98,7 +98,7 @@ class TestRefDbCreator(unittest.TestCase):
     def test__create_cdhit_cluster_file(self):
         expected_cluster = os.path.join(data_dir,'expected_cdhit_cluster.tsv')
         meta_data = os.path.join(data_dir,'meta.tsv')
-        temp_dir = tempfile.mkdtemp(prefix = 'temp_test', dir=os.getcwd())
+        temp_dir = tempfile.mkdtemp(prefix = 'temp_test')
         ref_db_creator.RefDbCreator._create_cdhit_cluster_file(temp_dir,meta_data)
         shutil.rmtree(temp_dir)
 
@@ -129,7 +129,7 @@ class TestRefDbCreator(unittest.TestCase):
         shutil.rmtree(out_dir)
 
     def test__create_complete_cdhit_cluster(self):
-        out_dir =  tempfile.mkdtemp(prefix = 'temp_test', dir=os.getcwd())
+        out_dir =  tempfile.mkdtemp(prefix = 'temp_test')
         expected = os.path.join(data_dir,'expected_complete_cdhit_cluster')
         meta_data = os.path.join(data_dir,'test_complete_meta.tsv')
         got = ref_db_creator.RefDbCreator._create_complete_cdhit_cluster(meta_data,out_dir)


### PR DESCRIPTION
I ran into the following issue trying to use the Seroba docker container

```
docker run --rm -u $(id -u):$(id -g) -v ${PWD}:/data quay.io/biocontainers/seroba:1.0.2--pyhdfd78af_1 seroba runSerotyping /data/sample7_1.fq.gz /data/sample7_2.fq.gz /data/test7
Traceback (most recent call last):
  File "/usr/local/bin/seroba", line 88, in <module>
    args.func(args)
  File "/usr/local/lib/python3.8/site-packages/seroba/tasks/sero_run.py", line 19, in run
    sero.run()
  File "/usr/local/lib/python3.8/site-packages/seroba/serotyping.py", line 468, in run
    self._run_kmc()
  File "/usr/local/lib/python3.8/site-packages/seroba/serotyping.py", line 55, in _run_kmc
    temp_dir = tempfile.mkdtemp(prefix = 'temp.kmc', dir=os.getcwd())
  File "/usr/local/lib/python3.8/tempfile.py", line 358, in mkdtemp
    _os.mkdir(file, 0o700)
PermissionError: [Errno 13] Permission denied: '/temp.kmco4ebdaal'
```

This PR allows `tempfile` to figure out where to make the temp dir (see https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir)

```
Python searches a standard list of directories to find one which the calling user can create files in. The list is:

The directory named by the TMPDIR environment variable.
The directory named by the TEMP environment variable.
The directory named by the TMP environment variable.
A platform-specific location:
    - On Windows, the directories C:\TEMP, C:\TMP, \TEMP, and \TMP, in that order
    - On all other platforms, the directories /tmp, /var/tmp, and /usr/tmp, in that order.

As a last resort, the current working directory.
```